### PR TITLE
Fix usage reset

### DIFF
--- a/Data/DBAccessor.cs
+++ b/Data/DBAccessor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Yumu
 {
@@ -116,20 +117,17 @@ namespace Yumu
             DBDirectory dir = GetReferencedDirectory(dirId); 
             if(dir != null) {
                 // Keep the image usage of already referenced images
-                /*Dictionary<string, DBImage> curImgs = _images
-                .Where(img => img.DirId == dir.Id)
-                .ToDictionary(img => img.SearchName);
-
-                List<DBImage> newImgs = dir.LookupImageFiles();
-
-                foreach(DBImage img in newImgs){
-                    if(curImgs.ContainsKey(img.SearchName)){
-                        img.Usage = curImgs[img.SearchName].Usage;
-                    }
-                }*/
-                List<DBImage> newImgs = dir.LookupImageFiles();
+                Dictionary<string, DBImage> curImgs = _images
+                .Where(img => img.DirId == dirId)
+                .ToDictionary(img => img.FileName);
 
                 RemoveReferencedImages(dirId);
+                List<DBImage> newImgs = dir.LookupImageFiles();
+                foreach(DBImage img in newImgs){
+                    if(curImgs.ContainsKey(img.FileName)){
+                        img.Usage = curImgs[img.FileName].Usage;
+                    }
+                }
                 AppendImageReferences(newImgs);
 
                 DB.UpdateContent<DBDirectory>(_directories.ToArray(), 

--- a/Data/DBAccessor.cs
+++ b/Data/DBAccessor.cs
@@ -115,9 +115,22 @@ namespace Yumu
         {
             DBDirectory dir = GetReferencedDirectory(dirId); 
             if(dir != null) {
+                // Keep the image usage of already referenced images
+                /*Dictionary<string, DBImage> curImgs = _images
+                .Where(img => img.DirId == dir.Id)
+                .ToDictionary(img => img.SearchName);
+
+                List<DBImage> newImgs = dir.LookupImageFiles();
+
+                foreach(DBImage img in newImgs){
+                    if(curImgs.ContainsKey(img.SearchName)){
+                        img.Usage = curImgs[img.SearchName].Usage;
+                    }
+                }*/
+                List<DBImage> newImgs = dir.LookupImageFiles();
+
                 RemoveReferencedImages(dirId);
-                List<DBImage> imgs = dir.LookupImageFiles();
-                AppendImageReferences(imgs);
+                AppendImageReferences(newImgs);
 
                 DB.UpdateContent<DBDirectory>(_directories.ToArray(), 
                 DIRS_DB_FILE);

--- a/Data/DBAccessor.cs
+++ b/Data/DBAccessor.cs
@@ -74,7 +74,7 @@ namespace Yumu
         {
             for(int i = 0; i < _directories.Count; ++i) {
                 if(_directories[i].Id == dirId) {
-                    RemoveRefrencedImages(dirId);
+                    RemoveReferencedImages(dirId);
                     
                     _directories.RemoveAt(i);
                     _dirsIdMap.Remove(dirId);
@@ -85,7 +85,7 @@ namespace Yumu
             }
         }
 
-        private void RemoveRefrencedImages(int dirId)
+        private void RemoveReferencedImages(int dirId)
         {
             int dirImgCount = GetReferencedDirectory(dirId).ImageCount;
             int swapEnd = _images.Count - 1;
@@ -115,7 +115,7 @@ namespace Yumu
         {
             DBDirectory dir = GetReferencedDirectory(dirId); 
             if(dir != null) {
-                RemoveRefrencedImages(dirId);
+                RemoveReferencedImages(dirId);
                 List<DBImage> imgs = dir.LookupImageFiles();
                 AppendImageReferences(imgs);
 

--- a/Utility/ImageUtils.cs
+++ b/Utility/ImageUtils.cs
@@ -12,8 +12,13 @@ namespace Yumu
         public static void CopyToClipboard(string imagePath)
         {   
             if(File.Exists(imagePath)) {
-                SetClipboardImage(Image.FromFile(imagePath), null, null);
-            } 
+                Image img;
+                using(Stream s = File.OpenRead(imagePath))
+                {
+                    img = Image.FromStream(s);
+                }
+                SetClipboardImage(img, null, null);
+            }
         }
 
         // https://stackoverflow.com/questions/44177115/copying-from-and-to-clipboard-loses-image-transparency
@@ -32,7 +37,7 @@ namespace Yumu
             if (imageNoTr == null)
                 imageNoTr = image;
             using (MemoryStream pngMemStream = new MemoryStream())
-            using (MemoryStream dibMemStream = new MemoryStream())
+            //using (MemoryStream dibMemStream = new MemoryStream())
             using (MemoryStream f17MemStream = new MemoryStream())
             {
                 // As standard bitmap, without transparency support

--- a/Utility/PreviewsLoader.cs
+++ b/Utility/PreviewsLoader.cs
@@ -90,7 +90,7 @@ namespace Yumu
             if(imgFile.Length > FILE_SIZE_LIMIT)
                 return null;
             
-            Image img;// = Image.FromFile(imgFile.FullName);
+            Image img;
             using(Stream s = File.OpenRead(imgFile.FullName))
             {
                 img = Image.FromStream(s);

--- a/Utility/PreviewsLoader.cs
+++ b/Utility/PreviewsLoader.cs
@@ -90,7 +90,11 @@ namespace Yumu
             if(imgFile.Length > FILE_SIZE_LIMIT)
                 return null;
             
-            Image img = Image.FromFile(imgFile.FullName);
+            Image img;// = Image.FromFile(imgFile.FullName);
+            using(Stream s = File.OpenRead(imgFile.FullName))
+            {
+                img = Image.FromStream(s);
+            }
             
             // Get image thumbnail that stays in the boundaries of a square
             // of size ROW_HEIGHT


### PR DESCRIPTION
Fixed usage counter of images being reset to 0 when the directory is reloaded in the directory manager form.
Also made images loaded for previews or clipboard be loaded from a stream. This avoids the need to dispose the image when the forms close.